### PR TITLE
gpt-4o-search-preview追加

### DIFF
--- a/backend-cdk/lambda/websocket/websock.py
+++ b/backend-cdk/lambda/websocket/websock.py
@@ -270,16 +270,26 @@ def lambda_handler(event, _):
             # gpt
             filtered_msgs = filter_messages(in_msgs, model)
             client = init_openai()
-            stream = client.chat.completions.create(  # pyright: ignore[reportCallIssue]
-                model=model,
-                messages=filtered_msgs,  # pyright: ignore[reportArgumentType]
-                stream=True,
-                user=userid,
-                temperature=temperatureGpt,
-                top_p=topPGpt,
-                frequency_penalty=frequencyPenaltyGpt,
-                presence_penalty=presencePenaltyGpt,
-            )
+            
+            # gpt-4o-search-preview doesn't support certain parameters
+            if model == Model.gpt4o_search.value:
+                stream = client.chat.completions.create(  # pyright: ignore[reportCallIssue]
+                    model=model,
+                    messages=filtered_msgs,  # pyright: ignore[reportArgumentType]
+                    stream=True,
+                    user=userid,
+                )
+            else:
+                stream = client.chat.completions.create(  # pyright: ignore[reportCallIssue]
+                    model=model,
+                    messages=filtered_msgs,  # pyright: ignore[reportArgumentType]
+                    stream=True,
+                    user=userid,
+                    temperature=temperatureGpt,
+                    top_p=topPGpt,
+                    frequency_penalty=frequencyPenaltyGpt,
+                    presence_penalty=presencePenaltyGpt,
+                )
             for chunk in stream:
                 if chunk.choices[0].delta.content is not None:
                     content = chunk.choices[0].delta.content

--- a/backend-cdk/lambda_layer/common/python/common.py
+++ b/backend-cdk/lambda_layer/common/python/common.py
@@ -30,6 +30,7 @@ class Model(Enum):
     gpt4turbo_preview = "gpt-4-0125-preview"
     gpt4turbo = "gpt-4-turbo-2024-04-09"
     gpt4o = "gpt-4o-2024-08-06"
+    gpt4o_search = "gpt-4o-search-preview"
     gpt4o_mini = "gpt-4o-mini"
     gpt4_5_preview = "gpt-4.5-preview-2025-02-27"
     gpt4_1 = "gpt-4.1-2025-04-14"
@@ -72,6 +73,7 @@ PRICE = {
     Model.gpt4turbo_preview.value: {"in": 0.01, "out": 0.03},
     Model.gpt4turbo.value: {"in": 0.01, "out": 0.03},
     Model.gpt4o.value: {"in": 0.0025, "out": 0.010},
+    Model.gpt4o_search.value: {"in": 0.0025, "out": 0.010},
     Model.gpt4_1.value: {"in": 0.002, "out": 0.008},
     Model.gpt4_1_mini.value: {"in": 0.0004, "out": 0.0016},
     Model.gpt4_1_nano.value: {"in": 0.0001, "out": 0.0004},

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -10,6 +10,7 @@ export const modelsGens: { [key: string]: string } = {
   "gpt-4-turbo-2024-04-09": "gpt-4-turbo",
   "gpt-4o-2024-05-13": "gpt-4o",
   "gpt-4o-2024-08-06": "gpt-4o",
+  "gpt-4o-search-preview": "gpt-4o-search",
   "gpt-4.5-preview-2025-02-27": "gpt-4.5-preview",
   "o1-mini-2024-09-12": "gpt-o1-mini",
   "o3-mini-2025-01-31": "gpt-o3-mini",


### PR DESCRIPTION
gpt-4o-search-previewモデル使用時に以下のパラメータを除外するように条件分岐を追加：
    - temperature
    - top_p
    - frequency_penalty
    - presence_penalty

料金がよくわからない。いったん仮導入
↓
$25.00 / 1000回のWeb検索。(APIコール１回ごとに1回)
```
Web search preview (non-reasoning models)
$25.00 / 1k calls + search content tokens are free
```
https://platform.openai.com/docs/pricing
